### PR TITLE
remove extra Algorithmia constants in specs

### DIFF
--- a/spec/features/5_algorithmia_spec.rb
+++ b/spec/features/5_algorithmia_spec.rb
@@ -26,7 +26,6 @@ end
 
 describe "/text-tag/new" do
   it "correctly generates tags", points: 5 do
-    Algorithmia = class_double("Algorithmia")
     text_tag_setup
 
     visit "/text-tag/new"
@@ -63,7 +62,6 @@ end
 
 describe "/colorize/new" do
   it "displays the colorized image", points: 5 do
-    Algorithmia = class_double("Algorithmia2")
     colorize_setup
 
     visit "/colorize/new"
@@ -99,7 +97,6 @@ end
 
 describe "/image-tag/new" do
   it "correctly generates tags", points: 5 do
-    Algorithmia = class_double("Algorithmia3")
     image_tag_setup
 
     visit "/image-tag/new"


### PR DESCRIPTION
I removed the Algorithmia constants defined in the specs that were leaving warning messages when run. I also created a branch on my forked repo with solutions to the Algorithmia exercises to test how the specs run without the constants that were previously there. 